### PR TITLE
Added support for different ACK codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -261,6 +261,19 @@
 					"default": true,
 					"description": "Send a ACK in response to messages received (HL7 Tools: Start Message Listener)."
 				},
+				"hl7tools.AckCode": {
+					"type": "string",
+					"default": "CA",
+					"enum": [
+						"AA",
+						"AE",
+						"AR",
+						"CA",
+						"CE",
+						"CR"
+					],
+					"description": "Value to use in MSA-1 of the ACK message when receiving a hl7 message."
+				},
 				"hl7tools.MaxLinesForFieldDescriptions": {
 					"type": "number",
 					"default": 200,
@@ -317,7 +330,7 @@
 		"eslint": "^8.20.0",
 		"glob": "^8.0.3",
 		"mocha": "^10.0.0",
-		"typescript": "^4.7.4"
+		"typescript": "^4.9.5"
 	},
 	"__metadata": {
 		"id": "b919e7cc-6fa1-454b-ab7f-216ed8d48f19",

--- a/src/ExtensionPreferences.ts
+++ b/src/ExtensionPreferences.ts
@@ -59,6 +59,10 @@ export class ExtensionPreferences {
 		return this._config['SendACK'];
 	}
 
+	get AckCode() {
+		return this._config['AckCode'];
+	}
+
 	get SocketEncodingPreference() {
 		// select the socket encoding defined in the preferences
 		switch (this._config['SocketEncoding']) {

--- a/src/TCPListener.ts
+++ b/src/TCPListener.ts
@@ -30,7 +30,7 @@ function GenerateAckFromMessage(HL7Message: string): string {
 	var delimiters: Delimiter = new Delimiter();
 	delimiters.ParseDelimitersFromMessage(HL7Message);
 	var ackMessage: string = "";
-
+	var preferences: ExtensionPreferences = new ExtensionPreferences();
 	// confirm the message received starts with a MSH segment.
 	// TO DO: add support for batch mode messages that start with FHS, BHS, BTS, or FTS segments. Also query field & component separator instead of assuming '|' & '^'. 
 	var hl7HeaderRegex: RegExp = new RegExp("^MSH\\" + delimiters.Field, "i");
@@ -43,7 +43,7 @@ function GenerateAckFromMessage(HL7Message: string): string {
 		if (mshFields.length < 12) {
 		}
 		else {
-			ackMessage = VT + "MSH" + delimiters.Field + delimiters.Component + delimiters.Repeat + delimiters.Escape + delimiters.SubComponent + delimiters.Field + "vscode-hl7tools" + delimiters.Field + mshFields[5] + delimiters.Field + mshFields[2] + delimiters.Field + mshFields[3] + delimiters.Field + messageTimestamp + delimiters.Field + delimiters.Field + "ACK" + delimiters.Component + mshFields[8].split(delimiters.Component)[1] + delimiters.Field + mshFields[9] + delimiters.Field + mshFields[10] + delimiters.Field + mshFields[11] + CR + "MSA" + delimiters.Field + "CA" + delimiters.Field + mshFields[9] + CR + FS + CR;
+			ackMessage = VT + "MSH" + delimiters.Field + delimiters.Component + delimiters.Repeat + delimiters.Escape + delimiters.SubComponent + delimiters.Field + "vscode-hl7tools" + delimiters.Field + mshFields[5] + delimiters.Field + mshFields[2] + delimiters.Field + mshFields[3] + delimiters.Field + messageTimestamp + delimiters.Field + delimiters.Field + "ACK" + delimiters.Component + mshFields[8].split(delimiters.Component)[1] + delimiters.Field + mshFields[9] + delimiters.Field + mshFields[10] + delimiters.Field + mshFields[11] + CR + "MSA" + delimiters.Field + preferences.AckCode + delimiters.Field + mshFields[9] + CR + FS + CR;
 		}
 	}
 	return ackMessage;


### PR DESCRIPTION
For some applications when receiving a HL7 message and sending an ACK the MSA-1 value in the ACK is required to be something other than 'CA' (often 'AA' is required).

I've added an extentsion setting where these can be changed, including error codes that may be useful when using this extension during development of new senders to validate handling of errors.

'CA' is retained as the default AckCode as to not disrupt users that already have this extension installed.