### PR TITLE
Various changes and fixes

### DIFF
--- a/src/TCPListener.ts
+++ b/src/TCPListener.ts
@@ -14,7 +14,7 @@ const VT: string = String.fromCharCode(0x0b);
 const FS: string = String.fromCharCode(0x1c);
 const CR: string = String.fromCharCode(0x0d);
 
-var listenerStarted: boolean = false;
+export var listenerStarted: boolean = false;
 var server: net.Server;
 var hl7Message: string = "";
 
@@ -106,7 +106,6 @@ export function StartListener(Port: number): void {
 		socket.addListener("end", function () {
 			socket.end();
 		});
-
 	});
 
 	// listen on specified port on all available interfaces
@@ -120,6 +119,12 @@ export function StartListener(Port: number): void {
 			listenerStarted = false;
 		}
 	});
+
+	setTimeout(() => {
+		if (listenerStarted) {
+			vscode.window.showInformationMessage(`The HL7 TCP listener has started on port: ${Port}.`);
+		}
+	}, 100);
 }
 
 //----------------------------------------------------


### PR DESCRIPTION
- Easy send message, added CodeLense, to fast open send message view

<img width="332" alt="image" src="https://github.com/RobHolme/vscode-hl7tools/assets/1212251/9fececdd-5efe-4507-857b-fbd731bc8db6">

- Checks for updates in VSCode settings, no need to reload VSCode

<img width="654" alt="image" src="https://github.com/RobHolme/vscode-hl7tools/assets/1212251/535f9279-4188-4807-b8c7-490028b35c0f">

- SendMessage View
  - Start/Stop Listener right from the view
  - when loses focus and returns back keeps form filled
  - will update the list of favorites if it was updated in settings
  - autofill the first favorite server