### PR TITLE
Potential fix for code scanning alert no. 2: Regular expression injection

### DIFF
--- a/src/TCPListener.ts
+++ b/src/TCPListener.ts
@@ -20,12 +20,6 @@ var hl7Message: string = "";
 
 
 //----------------------------------------------------
-// Escape a string so it can be safely used as a literal within a RegExp
-function escapeRegExp(literal: string): string {
-	return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-//----------------------------------------------------
 // Generate an ack message from the message header received.
 // Assuming standard segment delimiter is used '|'.
 // @param {string} Message - the HL7 message triggering the ACK.
@@ -39,7 +33,7 @@ function GenerateAckFromMessage(HL7Message: string): string {
 	var preferences: ExtensionPreferences = new ExtensionPreferences();
 	// confirm the message received starts with a MSH segment.
 	// TO DO: add support for batch mode messages that start with FHS, BHS, BTS, or FTS segments. Also query field & component separator instead of assuming '|' & '^'. 
-	var hl7HeaderRegex: RegExp = new RegExp("^MSH" + escapeRegExp(delimiters.Field), "i");
+	var hl7HeaderRegex: RegExp = new RegExp("^MSH" + Util.escapeRegExp(delimiters.Field), "i");
 	if (hl7HeaderRegex.test(HL7Message)) {
 		var mshFields: string[] = HL7Message.split(delimiters.Field);
 		// check length of MSH segment

--- a/src/TCPListener.ts
+++ b/src/TCPListener.ts
@@ -20,6 +20,12 @@ var hl7Message: string = "";
 
 
 //----------------------------------------------------
+// Escape a string so it can be safely used as a literal within a RegExp
+function escapeRegExp(literal: string): string {
+	return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+//----------------------------------------------------
 // Generate an ack message from the message header received.
 // Assuming standard segment delimiter is used '|'.
 // @param {string} Message - the HL7 message triggering the ACK.
@@ -33,7 +39,7 @@ function GenerateAckFromMessage(HL7Message: string): string {
 	var preferences: ExtensionPreferences = new ExtensionPreferences();
 	// confirm the message received starts with a MSH segment.
 	// TO DO: add support for batch mode messages that start with FHS, BHS, BTS, or FTS segments. Also query field & component separator instead of assuming '|' & '^'. 
-	var hl7HeaderRegex: RegExp = new RegExp("^MSH\\" + delimiters.Field, "i");
+	var hl7HeaderRegex: RegExp = new RegExp("^MSH" + escapeRegExp(delimiters.Field), "i");
 	if (hl7HeaderRegex.test(HL7Message)) {
 		var mshFields: string[] = HL7Message.split(delimiters.Field);
 		// check length of MSH segment

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -477,6 +477,12 @@ export abstract class Util {
 		});
 	}
 
+	//----------------------------------------------------
+	// Escape a string so it can be safely used as a literal within a RegExp
+	public static escapeRegExp(literal: string): string {
+		return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	}
+
 }
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/RobHolme/vscode-hl7tools/security/code-scanning/2](https://github.com/RobHolme/vscode-hl7tools/security/code-scanning/2)

In general, when constructing regular expressions with values derived from untrusted data, those values must be escaped so that any regex metacharacters are treated as literals. In JavaScript/TypeScript, this is typically done by replacing each regex metacharacter with an escaped version (for example, `.` becomes `\.`). This prevents the user-controlled value from altering the semantics or complexity of the regular expression.

For this codebase, the minimal and safest fix is to ensure that `delimiters.Field` is escaped before it is concatenated into the regex pattern in `GenerateAckFromMessage`. We can implement a small local helper function in `TCPListener.ts` that escapes all regex metacharacters, and then use it at the construction site of `hl7HeaderRegex`. This maintains existing behavior (we still match `"MSH"` followed by the actual HL7 field delimiter) but ensures that even if a malicious or malformed message sets the field delimiter to a regex metacharacter, it will be treated literally. No behavior elsewhere needs to be changed, since other uses of `delimiters.Field` (like `split(delimiters.Field)`) treat it as a simple string, not as a regex.

Concretely:
- In `src/TCPListener.ts`, above `GenerateAckFromMessage`, add a small `escapeRegExp` function that escapes regex metacharacters.
- Change line 36 from `new RegExp("^MSH\\" + delimiters.Field, "i");` to use the escaped field delimiter, e.g. `new RegExp("^MSH" + escapeRegExp(delimiters.Field), "i");`. This removes the hard-coded backslash (which was only correct for `|`) and instead escapes whatever delimiter is present.
- No changes are required in `src/Util.ts`; the parsing logic remains the same.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
